### PR TITLE
export-ignore on composer.lock

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,5 @@
 /phpunit.xml.dist       export-ignore
 /infection.json.dist    export-ignore
 /phpstan.neon           export-ignore
+/composer.lock          export-ignore
 /.*                     export-ignore


### PR DESCRIPTION
This will drop downloaded package size 380kb from to 196kb and save co2 :)