### PR TITLE
Incorporating the bank operation reference for unique identification

### DIFF
--- a/src/Banking/Operation.php
+++ b/src/Banking/Operation.php
@@ -104,7 +104,7 @@ class Operation extends Element
     {
         return $this->amount;
     }
-    
+
     public function getBankOperationReference(): ?string
     {
         return $this->bankOperationReference;

--- a/src/Banking/Operation.php
+++ b/src/Banking/Operation.php
@@ -35,7 +35,7 @@ class Operation extends Element
         private readonly ?string $currencyCode,
         private readonly ?string $rejectCode,
         private readonly ?string $exemptCode,
-        private readonly ?string $bankReference,
+        private readonly ?string $bankOperationReference,
     ) {
         $this->details = [];
     }
@@ -105,9 +105,9 @@ class Operation extends Element
         return $this->amount;
     }
     
-    public function getBankReference(): ?string
+    public function getBankOperationReference(): ?string
     {
-        return $this->bankReference;
+        return $this->bankOperationReference;
     }
 
     public function addDetails(OperationDetail $details): self

--- a/src/Banking/Operation.php
+++ b/src/Banking/Operation.php
@@ -35,6 +35,7 @@ class Operation extends Element
         private readonly ?string $currencyCode,
         private readonly ?string $rejectCode,
         private readonly ?string $exemptCode,
+        private readonly ?string $bankReference,
     ) {
         $this->details = [];
     }
@@ -102,6 +103,11 @@ class Operation extends Element
     public function getAmount(): float
     {
         return $this->amount;
+    }
+    
+    public function getBankReference(): ?string
+    {
+        return $this->bankReference;
     }
 
     public function addDetails(OperationDetail $details): self

--- a/src/Parser/Cfonb120/Line04Parser.php
+++ b/src/Parser/Cfonb120/Line04Parser.php
@@ -50,7 +50,7 @@ final class Line04Parser extends AbstractCfonb120Parser
             'exempt_code' => new RegexParts(LineParser::ALL, 1),
             '_unused_3' => new RegexParts(LineParser::ALL, 1),
             'amount' => new RegexParts(LineParser::AMOUNT, 13),
-            'bank_reference' => new RegexParts(LineParser::ALPHANUMERIC_BLANK, 16),
+            'bank_operation_reference' => new RegexParts(LineParser::ALPHANUMERIC_BLANK, 16),
         ]);
     }
 
@@ -72,7 +72,7 @@ final class Line04Parser extends AbstractCfonb120Parser
             $regexMatch->getStringOrNull('currency_code'),
             $regexMatch->getStringOrNull('reject_code'),
             $regexMatch->getStringOrNull('exempt_code'),
-            $regexMatch->getStringOrNull('bank_reference')
+            $regexMatch->getStringOrNull('bank_operation_reference')
         );
     }
 

--- a/src/Parser/Cfonb120/Line04Parser.php
+++ b/src/Parser/Cfonb120/Line04Parser.php
@@ -50,7 +50,7 @@ final class Line04Parser extends AbstractCfonb120Parser
             'exempt_code' => new RegexParts(LineParser::ALL, 1),
             '_unused_3' => new RegexParts(LineParser::ALL, 1),
             'amount' => new RegexParts(LineParser::AMOUNT, 13),
-            '_unused_5' => new RegexParts(LineParser::ALL, 16),
+            'bank_reference' => new RegexParts(LineParser::ALPHANUMERIC_BLANK, 16),
         ]);
     }
 
@@ -71,7 +71,8 @@ final class Line04Parser extends AbstractCfonb120Parser
             $regexMatch->getStringOrNull('internal_code'),
             $regexMatch->getStringOrNull('currency_code'),
             $regexMatch->getStringOrNull('reject_code'),
-            $regexMatch->getStringOrNull('exempt_code')
+            $regexMatch->getStringOrNull('exempt_code'),
+            $regexMatch->getStringOrNull('bank_reference')
         );
     }
 

--- a/src/Parser/RegexMatch.php
+++ b/src/Parser/RegexMatch.php
@@ -24,10 +24,10 @@ use Silarhi\Cfonb\Exceptions\ValueOfKeyIsNotNumericException;
 use function strlen;
 
 /** @internal */
-class RegexMatch
+readonly class RegexMatch
 {
     /** @var array<string, string|null> */
-    private readonly array $values;
+    private array $values;
 
     /**
      * @param array<string, RegexParts> $regexParts

--- a/src/Parser/RegexMatch.php
+++ b/src/Parser/RegexMatch.php
@@ -24,10 +24,10 @@ use Silarhi\Cfonb\Exceptions\ValueOfKeyIsNotNumericException;
 use function strlen;
 
 /** @internal */
-readonly class RegexMatch
+class RegexMatch
 {
     /** @var array<string, string|null> */
-    private array $values;
+    private readonly array $values;
 
     /**
      * @param array<string, RegexParts> $regexParts

--- a/tests/Banking/OperationTest.php
+++ b/tests/Banking/OperationTest.php
@@ -57,7 +57,7 @@ class OperationTest extends TestCase
         self::assertSame('test8', $sUT->getCurrencyCode());
         self::assertSame('test9', $sUT->getRejectCode());
         self::assertSame('test10', $sUT->getExemptCode());
-        self::assertSame('test11', $sUT->getBankReference());
+        self::assertSame('test11', $sUT->getBankOperationReference());
         self::assertCount(0, $sUT->getDetails());
 
         $detail = $this->createMock(OperationDetail::class);

--- a/tests/Banking/OperationTest.php
+++ b/tests/Banking/OperationTest.php
@@ -40,9 +40,10 @@ class OperationTest extends TestCase
             'test7',
             'test8',
             'test9',
-            'test10'
+            'test10',
+            'test11',
         );
-
+        
         self::assertSame('test', $sUT->getBankCode());
         self::assertSame('test2', $sUT->getDeskCode());
         self::assertSame('test3', $sUT->getAccountNumber());
@@ -56,6 +57,7 @@ class OperationTest extends TestCase
         self::assertSame('test8', $sUT->getCurrencyCode());
         self::assertSame('test9', $sUT->getRejectCode());
         self::assertSame('test10', $sUT->getExemptCode());
+        self::assertSame('test11', $sUT->getBankReference());
         self::assertCount(0, $sUT->getDetails());
 
         $detail = $this->createMock(OperationDetail::class);

--- a/tests/Banking/OperationTest.php
+++ b/tests/Banking/OperationTest.php
@@ -43,7 +43,7 @@ class OperationTest extends TestCase
             'test10',
             'test11',
         );
-        
+
         self::assertSame('test', $sUT->getBankCode());
         self::assertSame('test2', $sUT->getDeskCode());
         self::assertSame('test3', $sUT->getAccountNumber());


### PR DESCRIPTION
First of all, thank you for your excellent work on this project!

This PR adds support for handling the operation reference from the CFONB120 files (positions 105–120 of a type 04 line). This field corresponds to the Account Servicer Reference as defined in the ISO20022 standard.

After discussing the terminology, I opted to name the new field bankOperationReference. I found that the term "Account Servicer Reference" may be unclear for users, and "bankOperationReference" better conveys that it is the reference provided by the bank to uniquely identify the operation.

This change is essential for our reconciliation process of bank transfers, as we also process messages following the ISO20022 standard. In our scenario, the only way to uniquely identify an operation for the same bank is through this reference.

I have updated the related tests to ensure that the new field is correctly parsed and accessible.

Thank you again for the project, and I look forward to your feedback!