### PR TITLE
Set PHPStan to maximum level and fix errors

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-	level: 9
+	level: max
 	paths:
 		- src
 		- tests


### PR DESCRIPTION
Using 'max' instead of '9' ensures the highest strictness level is always used, even if future PHPStan versions introduce higher levels.