### PR TITLE
chore: update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
     "require-dev": {
         "dg/bypass-finals": "^1.9",
         "friendsofphp/php-cs-fixer": "^3.94.2",
-        "phpstan/phpstan": "^2.1.42",
-        "phpunit/phpunit": "^10.5.26|^11.5.50|^12.0|^13.0",
+        "phpstan/phpstan": "^2.1.44",
+        "phpunit/phpunit": "^10.5.26|^11.5.55|^12.0|^13.0",
         "rector/rector": "^2.3.9",
         "rector/swiss-knife": "^2.3.5",
-        "vimeo/psalm": "^5.26|^6.14.3"
+        "vimeo/psalm": "^5.26|^6.16.1"
     },
     "autoload": {
         "psr-4": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -206,6 +206,6 @@ wrap-ansi@^9.0.0:
     strip-ansi "^7.1.0"
 
 yaml@^2.8.2:
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.2.tgz#5694f25eca0ce9c3e7a9d9e00ce0ddabbd9e35c5"
-  integrity sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.3.tgz#a0d6bd2efb3dd03c59370223701834e60409bd7d"
+  integrity sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==


### PR DESCRIPTION
Automated dependency update - March 2026

## PHP updates (composer)
- `phpstan/phpstan`: 2.1.37 → 2.1.44
- `phpunit/phpunit`: 11.5.50 → 11.5.55
- `friendsofphp/php-cs-fixer`: 3.93.1 → 3.94.2
- `rector/rector`: 2.3.5 → 2.3.9
- `vimeo/psalm`: 6.14.3 → 6.16.1
- `symfony/*`: minor patch updates
- Various transitive dependency updates

## JS updates (yarn)
- `yaml`: 2.8.2 → 2.8.3

## Checks
- ✅ PHPStan: no errors
- ✅ PHPUnit: 86 tests, 503 assertions
- ✅ PHP-CS-Fixer: no fixes needed