### PR TITLE
chore: add PHPUnit 13 support

### DIFF
--- a/tests/Banking/OperationTest.php
+++ b/tests/Banking/OperationTest.php
@@ -60,7 +60,7 @@ final class OperationTest extends TestCase
         self::assertSame('test11', $sUT->getBankOperationReference());
         self::assertCount(0, $sUT->getDetails());
 
-        $detail = $this->createMock(OperationDetail::class);
+        $detail = $this->createStub(OperationDetail::class);
 
         $sUT->addDetails($detail);
 

--- a/tests/Banking/StatementTest.php
+++ b/tests/Banking/StatementTest.php
@@ -30,8 +30,8 @@ final class StatementTest extends TestCase
         self::assertFalse($sUT->hasNewBalance());
         self::assertFalse($sUT->hasOldBalance());
 
-        $newBalance = $this->createMock(Balance::class);
-        $oldBalance = $this->createMock(Balance::class);
+        $newBalance = $this->createStub(Balance::class);
+        $oldBalance = $this->createStub(Balance::class);
 
         $sUT->setNewBalance($newBalance);
         $sUT->setOldBalance($oldBalance);

--- a/tests/Banking/TransferTest.php
+++ b/tests/Banking/TransferTest.php
@@ -45,9 +45,9 @@ final class TransferTest extends TestCase
     /** @return void */
     public function testOk()
     {
-        $total = $this->createMock(Total::class);
-        $header = $this->createMock(Header::class);
-        $transaction = $this->createMock(Transaction::class);
+        $total = $this->createStub(Total::class);
+        $header = $this->createStub(Header::class);
+        $transaction = $this->createStub(Transaction::class);
 
         $sUT = new Transfer();
         $sUT->setHeader($header);


### PR DESCRIPTION
Add PHPUnit 13 compatibility while keeping BC with PHPUnit 10/11/12.

Changes:
- Updated phpunit constraint to `^10|^11|^12|^13`
- Replaced `createMock()` with `createStub()` where no expectations are set (PHPUnit 13 requirement)

All 86 tests pass ✅