### PR TITLE
Add composer-normalize and composer validate CI check

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,0 +1,12 @@
+{
+    "additional_checks": [
+        {
+            "name": "Composer validate & normalize",
+            "job": {
+                "php": "@lowest",
+                "dependencies": "latest",
+                "command": "composer validate --strict && composer normalize --dry-run --diff"
+            }
+        }
+    ]
+}

--- a/composer.json
+++ b/composer.json
@@ -18,18 +18,16 @@
     "require": {
         "php": ">=8.2"
     },
-    "config": {
-        "bump-after-update": "dev"
-    },
     "require-dev": {
         "dg/bypass-finals": "^1.9",
+        "ergebnis/composer-normalize": "^2.52",
         "friendsofphp/php-cs-fixer": "^3.95.2",
         "phpstan/phpstan": "^2.1.56",
         "phpstan/phpstan-strict-rules": "^2.0.11",
-        "phpunit/phpunit": "^11.5.55|^12|^13.0.5",
+        "phpunit/phpunit": "^11.5.55 || ^12 || ^13.0.5",
         "rector/rector": "^2.4.5",
         "rector/swiss-knife": "^2.4.1",
-        "vimeo/psalm": "^5.26|^6.16.1"
+        "vimeo/psalm": "^5.26 || ^6.16.1"
     },
     "autoload": {
         "psr-4": {
@@ -40,5 +38,11 @@
         "psr-4": {
             "Silarhi\\Cfonb\\Tests\\": "tests/"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "ergebnis/composer-normalize": true
+        },
+        "bump-after-update": "dev"
     }
 }


### PR DESCRIPTION
## Summary

- Add `ergebnis/composer-normalize` as a dev dependency (with its `allow-plugins` entry)
- Normalize `composer.json` (canonical key order, ` || ` constraint separators)
- Add a CI check via `.laminas-ci.json` `additional_checks`: `composer validate --strict && composer normalize --dry-run --diff` on lowest PHP with latest dependencies

## Test plan

- [x] `composer validate --strict` passes locally
- [x] `composer normalize --dry-run` passes locally
- [x] `.laminas-ci.json` validated against the official laminas-ci JSON schema
- [ ] CI matrix picks up the new "Composer validate & normalize" job