### PR TITLE
chore: add composer validate & normalize CI check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,14 @@
         "php": ">=8.2"
     },
     "require-dev": {
-        "dg/bypass-finals": "^1.9",
+        "dg/bypass-finals": "^1.10.2",
         "ergebnis/composer-normalize": "^2.52",
-        "friendsofphp/php-cs-fixer": "^3.95.2",
-        "phpstan/phpstan": "^2.1.56",
+        "friendsofphp/php-cs-fixer": "^3.95.7",
+        "phpstan/phpstan": "^2.2.2",
         "phpstan/phpstan-strict-rules": "^2.0.11",
         "phpunit/phpunit": "^11.5.55 || ^12 || ^13.0.5",
         "rector/rector": "^2.4.5",
-        "rector/swiss-knife": "^2.4.1",
+        "rector/swiss-knife": "^2.4.4",
         "vimeo/psalm": "^5.26 || ^6.16.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "allow-plugins": {
             "ergebnis/composer-normalize": true
         },
-        "bump-after-update": "dev"
+        "bump-after-update": "dev",
+        "sort-packages": true
     }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
         "lint-staged": ">=15.2.10"
     },
     "lint-staged": {
-        "*.php": "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php"
+        "*.php": "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php",
+        "composer.json": "composer normalize"
     },
     "scripts": {
         "prepare": "husky"


### PR DESCRIPTION
Adds composer.json quality enforcement, consistent with `silarhi/picasso-bundle`:

- `ergebnis/composer-normalize` dev dependency + its `allow-plugins` entry
- lint-staged hook running `composer normalize` on `composer.json`
- new `.laminas-ci.json` `additional_checks` step running `composer validate --strict && composer normalize --dry-run --diff`
- `config.sort-packages` enabled (separate commit)
